### PR TITLE
Fixed restriction on all user routes, adjusted seeds

### DIFF
--- a/api/api_router.js
+++ b/api/api_router.js
@@ -6,7 +6,7 @@ const videosRouter = require("../videos/videos_router.js");
 const songsRouter = require("../songs/songs_router");
 
 router.use("/auth", authRouter);
-router.use("/users", restricted, userRouter);
+router.use("/users", userRouter);
 router.use("/videos", videosRouter);
 router.use("/songs", restricted, songsRouter);
 

--- a/data/seeds/03_videos.js
+++ b/data/seeds/03_videos.js
@@ -53,8 +53,8 @@ exports.seed = function (knex, Promise) {
         },
         {
           video_title: "Tuxedos Floating on a River",
-          location: "https://artificial-artist.s3.amazonaws.com/bri1.mp4",
-          thumbnail: "https://i.imgur.com/2Zfzdcw.jpg",
+          location: "https://artificial-artist.s3.amazonaws.com/hq-demo2.mp4",
+          thumbnail: "https://artificial-artist.s3.amazonaws.com/hq-demo2.jpg",
           video_status: "successful",
           song_id: 7,
           user_id: 1,
@@ -64,14 +64,14 @@ exports.seed = function (knex, Promise) {
           location:
             "https://artificial-artist.s3.amazonaws.com/TarantulaCrisp.mp4",
           thumbnail: "https://i.imgur.com/2Zfzdcw.jpg",
-          video_status: "failed",
+          video_status: "successful",
           song_id: 8,
           user_id: 1,
         },
         {
           video_title: "the way of the web",
-          location: "https://artificial-artist.s3.amazonaws.com/3.mp4",
-          thumbnail: "https://i.imgur.com/2Zfzdcw.jpg",
+          location: "https://artificial-artist.s3.amazonaws.com/hq-demo1.mp4",
+          thumbnail: "https://artificial-artist.s3.amazonaws.com/hq-demo1.jpg",
           video_status: "successful",
           song_id: 9,
           user_id: 1,

--- a/data/seeds/03_videos.js
+++ b/data/seeds/03_videos.js
@@ -13,8 +13,8 @@ exports.seed = function (knex, Promise) {
         },
         {
           video_title: "Cali Loves Mashed Potatoes",
-          location: "https://artificial-artist.s3.amazonaws.com/CAlove.mp4",
-          thumbnail: "https://i.imgur.com/2Zfzdcw.jpg",
+          location: "https://artificial-artist.s3.amazonaws.com/hq-demo3.mp4",
+          thumbnail: "https://artificial-artist.s3.amazonaws.com/hq-demo3.jpg",
           video_status: "successful",
           song_id: 2,
           user_id: 1,
@@ -61,7 +61,8 @@ exports.seed = function (knex, Promise) {
         },
         {
           video_title: "TarantulaCrisp",
-          location: "https://artificial-artist.s3.amazonaws.com/TarantulaCrisp.mp4",
+          location:
+            "https://artificial-artist.s3.amazonaws.com/TarantulaCrisp.mp4",
           thumbnail: "https://i.imgur.com/2Zfzdcw.jpg",
           video_status: "failed",
           song_id: 8,
@@ -117,8 +118,7 @@ exports.seed = function (knex, Promise) {
         },
         {
           video_title: "Collies on my mind",
-          location:
-            "https://artificial-artist.s3.amazonaws.com/bri2.mp4",
+          location: "https://artificial-artist.s3.amazonaws.com/bri2.mp4",
           thumbnail: "https://imgur.com/lLeteDr",
           video_status: "successful",
           song_id: 9,


### PR DESCRIPTION
# Description

Fixed issue with all user routes being restricted, which prevented profile pages from loading. Getting all users is still restricted.

Also updated seeds for `user1` to have hq videos

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [x] Manually

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
